### PR TITLE
Add option to force chat preview

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,14 +5,14 @@ org.gradle.daemon=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.8
+loader_version=0.14.9
 
 # Mod Properties
-mod_version = 1.19-1.5
+mod_version = 1.19.2-1.6
 maven_group = io.alwa
 archives_base_name = featuredservers
 
 # Dependencies
-fabric_version=0.55.1+1.19
+fabric_version=0.60.0+1.19.2

--- a/src/main/java/io/alwa/featuredservers/FeaturedList.java
+++ b/src/main/java/io/alwa/featuredservers/FeaturedList.java
@@ -1,8 +1,10 @@
 package io.alwa.featuredservers;
 
+import io.alwa.featuredservers.mixin.ChatPreviewMixin;
 import io.alwa.featuredservers.mixin.ServerListAccessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.network.ServerInfo.ChatPreview;
 import net.minecraft.client.option.ServerList;
 import org.apache.logging.log4j.Level;
 
@@ -21,7 +23,15 @@ public class FeaturedList {
         int i = 0;
         for (FeaturedServers.ServerDataHelper serverHelp : featuredList) {
             FeaturedServerData server = new FeaturedServerData(serverHelp.getServerName(), serverHelp.getServerIP(), false, serverHelp.doesDisableButtons());
-            if(serverHelp.doesForceResourcePack() != null && serverHelp.doesForceResourcePack()) server.setResourcePackPolicy(ServerInfo.ResourcePackPolicy.ENABLED);
+            if (serverHelp.doesForceResourcePack() != null && serverHelp.doesForceResourcePack()) server.setResourcePackPolicy(ServerInfo.ResourcePackPolicy.ENABLED);
+            if (serverHelp.doesForceChatPreview() != null && serverHelp.doesForceChatPreview()) {
+                server.setPreviewsChat(true);
+                ChatPreview chatPreview = server.getChatPreview();
+                if (chatPreview != null) {
+                    chatPreview.setAcknowledged();
+                    ((ChatPreviewMixin) chatPreview).setToastShown(true);
+                }
+            }
             if (inList(server, serverList)) {
                 FeaturedServers.LOGGER.log(Level.INFO, "Featured server already in server list");
             } else {

--- a/src/main/java/io/alwa/featuredservers/FeaturedServers.java
+++ b/src/main/java/io/alwa/featuredservers/FeaturedServers.java
@@ -40,12 +40,14 @@ public class FeaturedServers implements ClientModInitializer {
                             "serverName": "Featured Server",
                             "serverIP": "127.0.0.1",
                             "forceResourcePack": "true",
+                            "forceChatPreview": "true",
                             "disableButtons": "true"
                         },
                         {
                             "serverName": "Another Server!",
                             "serverIP": "192.168.1.1",
                             "forceResourcePack": "false",
+                            "forceChatPreview": "false",
                             "disableButtons": "false"
                         }
                     ]
@@ -71,6 +73,7 @@ public class FeaturedServers implements ClientModInitializer {
         private String serverName;
         private String serverIP;
         private Boolean forceResourcePack;
+        private Boolean forceChatPreview;
         private Boolean disableButtons;
 
         public String getServerName() {
@@ -79,6 +82,10 @@ public class FeaturedServers implements ClientModInitializer {
 
         public String getServerIP() {
             return serverIP;
+        }
+
+        public Boolean doesForceChatPreview() {
+            return forceChatPreview;
         }
 
         public Boolean doesForceResourcePack() {

--- a/src/main/java/io/alwa/featuredservers/mixin/ChatPreviewMixin.java
+++ b/src/main/java/io/alwa/featuredservers/mixin/ChatPreviewMixin.java
@@ -1,0 +1,12 @@
+package io.alwa.featuredservers.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.network.ServerInfo.ChatPreview;
+
+@Mixin(ChatPreview.class)
+public interface ChatPreviewMixin {
+    @Accessor("toastShown")
+    public void setToastShown(boolean toastShown);
+}

--- a/src/main/resources/featuredservers.mixins.json
+++ b/src/main/resources/featuredservers.mixins.json
@@ -9,7 +9,8 @@
     "ServerEntryMixin",
     "ServerListAccessor",
     "MultiplayerServerListWidgetAccessor",
-    "DrawableHelperMixin"
+    "DrawableHelperMixin",
+    "ChatPreviewMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR adds an option to force chat preview to be enabled for the server and both popup message and toast to be dismissed. This option is useful for mod packs that were created for the SMPs where chat preview provides useful functionality - for example, this SMP may use Essentials plugin chat formatting. This does not take away player's ability to disable chat preview (for privacy or other reasons), this is still can be changed through game settings.

Since chat preview was introduced in 1.19.1, the mod targeted Minecraft version has been changed to 1.19.2 (the most recent version that fixed multiple exploits related to chat reporting).